### PR TITLE
Changes needed for Xcode version 6.3 and swift 1.2

### DIFF
--- a/DynamicPageViewController/DMDynamicViewController.swift
+++ b/DynamicPageViewController/DMDynamicViewController.swift
@@ -73,7 +73,7 @@ class DMDynamicViewController: UIViewController, UIScrollViewDelegate {
     var delegate: DMDynamicPageViewControllerDelegate? = nil
                             
     init(viewControllers: Array<UIViewController>) {
-        super.init()
+        super.init(nibName: nil, bundle: nil)
         self.viewControllers = viewControllers
         self.notifyDelegateDidChangeControllers()
     }


### PR DESCRIPTION
The project fails to compile on the update version of Xcode i.e 6.3. A minimal fix: adding parameters to super.init function call solves the issue.
super.init(nibName: nil, bundle: nil)
