### PR TITLE
Bugfixes and PageControl

### DIFF
--- a/DynamicPageViewController/DMDynamicViewController.swift
+++ b/DynamicPageViewController/DMDynamicViewController.swift
@@ -154,7 +154,7 @@ class DMDynamicViewController: UIViewController, UIScrollViewDelegate {
         containerScrollView.backgroundColor = UIColor.grayColor()
         var dots = UIPageControl()
         dots.setTranslatesAutoresizingMaskIntoConstraints(false)
-        //dots.enabled = false
+        dots.enabled = false
         self.pageWidth = self.view.frame.size.width
         self.view.addSubview(containerScrollView)
         


### PR DESCRIPTION
Hello,

The currentPage and fullySwitchedPage variables were NOT being updated at page switch due to a small mistake in the ScrollView delegate, and thus the DMDynamicPageViewController delegate was also getting the wrong page every time it was triggered. I have fixed that.

I have also added the navigation dots, just like the actual UIPageViewController, and got them to update when the page is switched and new pages are added.

Thanks for considering request -
Cem Gokmen
